### PR TITLE
Remove link to site that distributes copyrighted materials

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,8 +173,6 @@
               programmeringssprog (PyCharm, IntelliJ IDEA osv.).</li>
             <li>Gratis <a target="_blank" href="http://www.autodesk.com"><strong>Autodesk</strong></a>-programmel for studerende.</li>
           </ul>
-		  <h2>Undervisningsmateriale til årgang '14</h2>
-		  En spejlning af det meste af undervisningsmaterialet til de aktuelle kurser for årgang '14 findes på <a target="_blank" href="http://uni.frenzel.dk"><strong>uni.frenzel.dk</strong></a>.
 
           <h2>Bidrag</h2>
           <tt>ucph.dk</tt>


### PR DESCRIPTION
I don't think it is a good idea to link to a site that distributes copyrighted materials.