### PR TITLE
Rettet øjebrændende fejl.

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
             er <a href="http://www.diku.dk/Ansatte/?pure=da/persons/160232">
             Jørgen Bansler</a>, viceinstitutleder for forskning
             er <a href="http://www.diku.dk/Ansatte/?pure=da/persons/89506">Jakob
-            Grue</a> og viceinstitutleder for undervisning ("VILU")
+            Grue</a>, og viceinstitutleder for undervisning ("VILU")
             er <a href="http://www.diku.dk/Ansatte/?pure=da/persons/110537">Kenny
             Erleben</a>.
           </p>


### PR DESCRIPTION
Per dansk sproglovgivning skal der være et komma mellem to helsætninger!