### PR TITLE
Opdateret mail og ændret i kursestilmelding

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,14 +269,12 @@
 
           <h2>Kursustilmelding</h2>
           <p>
-            Kursustilmelding foregår to gange om året.  Tilmelding til kurser
-            i <em>blok 1 og 2</em> foregår i de to uger op til d.  1. juni, og
-            tilmelding til <em>blok 3 og 4</em> er i de to uger op til
-            d. 1. november
-            (<a href="files/SFR Årshjul fælles frister_jan. 15.pdf">kilde</a>).
-            Tilmelding foregår på <a href="http://kunet.dk">KUnet</a>,
-            under <em>Selvbetjening</em>, <em>Indskrivning, Undervisning &amp;
-            Eksamen</em>, <em>Undervisning</em>.
+            Kursustilmelding foregår to gange om året.
+            Tilmeldingsperioderne kan findes på
+            <a href="https://intranet.ku.dk/datalogi_ba/Sider/default.aspx">studiesiden</a>
+            eller i
+            <a href="http://science.ku.dk/uddannelser/studerende/studiekalender/">
+            studiekalenderen</a>
           </p>
 
           <h2>Eksamenstilmelding</h2>
@@ -291,7 +289,7 @@
             Hvis du har problemer eller spørgsmål omkring dit virke
             som studerende, så skriv
             til <a href="http://www.science.ku.dk/uddannelser/studenterservice/">Studenterservice</a>
-            (studievejledning@science.ku.dk).  Selv hvis de ikke kan
+            (studenterservice@science.ku.dk).  Selv hvis de ikke kan
             hjælpe dig, så kan de sikkert fortælle hvem der kan.
           </p>
 


### PR DESCRIPTION
Inde på en facebookgruppe for nye studerende delte jeg et link til siden og Ann fra administrationen sendte mig så denne mail. 

>Jeg har lige set, at I har linket til denne side inde på Facebook: http://ucph.dk/. Jeg er glad for, at I gerne vil hjælpe de studerende godt i gang og det er også en sjov side. Men det bekymrer mig lidt, at der er faktuelle fejl, såsom mailadressen til studenterservice (studenterservice@science.ku.dk og ikke studievejledning@science.ku.dk, som I skriver) og at I skriver om kursustilmelding osv. Information som dette bliver lynhurtigt ændret, og vi vil rigtig gerne ”opdrage” de nye studerende til at bruge uddannelsessiderne i stedet: https://intranet.ku.dk/datalogi_ba/Sider/default.aspx. Her vil de altid finde den korrekte information om deres studie, da SCIENCE er ansvarlige for at opdatere det. Vi har før oplevet klager over fx nogen, der havde misset deres eksaminer, fordi de har læst eksamensplaner osv. på alternative portaler. Så jeg vil være rigtig glad, hvis I vil ændre siden til at linke ind til uddannelsessiden på KUnet for at finde de forskellige informationer. Hvordan opdaterer I kalenderen derinde, er det informationer fra diku.dk?

Jeg har opdateret mailadressen og ændret lidt i tilmeldingsoplysninger. 
Det kan godt være der er en smartere måde at præsentere informationen på. 