### PR TITLE
Rettet DICON, tilfoejet undervisningsledere og opdateret optagelsestal

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@
         <div id="forside-hoejre">
           <h2>Nøgledata om DIKU</h2>
           <p>
-            <em>Sidst opdateret 21. maj 2021.</em>
+            <em>Sidst opdateret 23. juni 2023.</em>
           </p>
           <p>
             Institutlederen

--- a/index.html
+++ b/index.html
@@ -98,8 +98,9 @@
               anime</a>
             </li>
             <li>
-              <a href="https://www.facebook.com/groups/diconbraetspil/">DICON
-              (brætspil)</a>
+              <a href="https://www.facebook.com/groups/diconbraetspil/">DICON Brætspil</a>
+              (<a href="https://github.com/DICON-Braetspil">Github</a>;
+	       email: <code>dicon@di.ku.dk</code>)
             </li>
             <li>
               DIKU Ski
@@ -257,14 +258,17 @@
           <p>
             Mere væsentligt, så
             er <a href="http://www.diku.dk/~torbenm/">Torben
-            Mogensen</a> undervisningsleder for bacheloruddannelsen,
+            Mogensen</a> undervisningsleder for bacheloruddannelsen på Datalogi,
+	    <a href="https://di.ku.dk/Ansatte/?pure=da/persons/127388">Martin Elsman</a> er undervisningsleder
+	    på Datalogi-økonomi, <a href="https://forskning.ku.dk/soeg/result/?pure=da/persons/254908">
+	    Stefan Sommer</a> på Machine learning og datavidenskab
             og <a href="https://research.ku.dk/search/result/?pure=en%2Fpersons%2F590429">Yongluan
             Zhou</a> leder for kandidatuddannelsen.  Skriv til dem
             hvis du har et studierelateret problem eller spørgsmål.
           </p>
           <p>
-            I 2020 blev der optaget 250 på datalogi, 98 på
-            Datalogi-økonomi, og 98 på Machine learning og
+            I 2022 blev der optaget 220 på datalogi, 88 på
+            Datalogi-økonomi, og 65 på Machine learning og
             datavidenskab.  DIKU er beliggende i Universitetsparken 1
             (studiepladser, studenterkantinen, en del undervisning),
             Universitetsparken 5 (APL-forskergruppen), Sigurdsgade 41


### PR DESCRIPTION
Rettede DICON til det (nye?) navn, DICON Brætspil, samt tilføjet Github og email.
Tilføjet Stefan Sommer og Martin Elsman som undervisningsledere da alle tre uddannelser kan drage nytte af hjemmesiden, og nøgletallene er opdateret til 2022 baseret på følgende kilde: https://di.ku.dk/ominstituttet/ansoegningstal/ 